### PR TITLE
chore: switch to ucdjs domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Unicode Proxy is a lightweight intermediary between your requests and the [Unico
 Fetch a JSON listing of files from a directory:
 
 ```bash
-curl https://unicode-proxy.mojis.dev/proxy
+curl https://unicode-proxy.ucdjs.dev/proxy
 ```
 
 ### Get a File
@@ -22,7 +22,7 @@ curl https://unicode-proxy.mojis.dev/proxy
 Retrieve the raw contents of a specific file:
 
 ```bash
-curl https://unicode-proxy.mojis.dev/proxy/path/to/file
+curl https://unicode-proxy.ucdjs.dev/proxy/path/to/file
 ```
 
 > [!NOTE]

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,7 +19,7 @@
       },
       "route": {
         "custom_domain": true,
-        "pattern": "unicode-proxy.preview.mojis.dev"
+        "pattern": "unicode-proxy.preview.ucdjs.dev"
       }
     },
     "production": {
@@ -30,7 +30,7 @@
       },
       "route": {
         "custom_domain": true,
-        "pattern": "unicode-proxy.mojis.dev"
+        "pattern": "unicode-proxy.ucdjs.dev"
       }
     }
   }


### PR DESCRIPTION
This was recently transferred from @mojisdev/unicode-proxy to @ucdjs/unicode-proxy.